### PR TITLE
tickets/OSW 675: Add timezone awareness to timestamp conversion

### DIFF
--- a/doc/news/OSW-675.bugfix.rst
+++ b/doc/news/OSW-675.bugfix.rst
@@ -1,0 +1,1 @@
+Added timezone awareness to timestamp conversion.

--- a/python/lsst/ts/weatherforecast/csc.py
+++ b/python/lsst/ts/weatherforecast/csc.py
@@ -33,6 +33,7 @@ import math
 import os
 import pathlib
 import types
+import zoneinfo
 
 import aiohttp
 from lsst.ts import salobj, utils
@@ -155,7 +156,11 @@ class WeatherForecastCSC(salobj.ConfigurableCsc):
         result : `float`
             A timestamp float converted from string.
         """
-        result: float = datetime.datetime.strptime(timestamp, "%Y-%m-%d %H:%M").timestamp()
+        result: float = (
+            datetime.datetime.strptime(timestamp, "%Y-%m-%d %H:%M")
+            .replace(tzinfo=zoneinfo.ZoneInfo("America/Santiago"))
+            .timestamp()
+        )
         return result
 
     async def telemetry(self) -> None:
@@ -173,7 +178,7 @@ class WeatherForecastCSC(salobj.ConfigurableCsc):
                 await self.fault(code=1, report="Number of retries exceeded max retries.")
                 return
             if not self.simulation_mode:
-                time = datetime.datetime.now()
+                time = datetime.datetime.now(tz=zoneinfo.ZoneInfo("America/Santiago"))
             else:
                 time = datetime.datetime(year=2024, month=12, day=1, hour=4, minute=0, second=0)
             if (time.hour in [4, 16] or self.first_time) and not self.already_updated:

--- a/tests/data/config/_init.yaml
+++ b/tests/data/config/_init.yaml
@@ -1,1 +1,1 @@
-tel_loop_error_wait_time: 5
+tel_loop_error_wait_time: 10

--- a/tests/test_csc.py
+++ b/tests/test_csc.py
@@ -26,6 +26,7 @@ import pathlib
 import re
 import unittest
 import typing
+from zoneinfo import ZoneInfo
 
 from lsst.ts import salobj, weatherforecast
 from pytest import approx
@@ -74,7 +75,7 @@ class WeatherForecastCSCTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsynci
             config_dir=TEST_CONFIG_DIR,
         ):
             await self.assert_next_summary_state(state=salobj.State.ENABLED)
-            await self.assert_next_summary_state(state=salobj.State.FAULT)
+            await self.assert_next_summary_state(state=salobj.State.FAULT, timeout=TIMEOUT)
 
     def check_arrays(self, response: dict, expected: dict, length: int) -> None:
         missing_names = []
@@ -85,7 +86,9 @@ class WeatherForecastCSCTestCase(salobj.BaseCscTestCase, unittest.IsolatedAsynci
                 assert values[:length] == approx(expected[name][:length])
             elif name == "timestamp":
                 converted_timestamps = [
-                    datetime.datetime.strptime(timestamp, "%Y-%m-%d %H:%M").timestamp()
+                    datetime.datetime.strptime(timestamp, "%Y-%m-%d %H:%M")
+                    .replace(tzinfo=ZoneInfo("America/Santiago"))
+                    .timestamp()
                     for timestamp in expected["time"]
                 ]
                 assert values[:length] == approx(converted_timestamps[:length])


### PR DESCRIPTION

Since we receive a time string from the MeteoBlue API, we need to convert that value into a timestamp in order to be published over SAL.
This creates an issue where the timestamp0 is not aligned with data from the WeatherStation and thus an offset needs to be introduced in order to make the prediction curve match the real data better.
Originally this timestamp conversion did not account for the timezone information and so this PR adds timezone information before converting into a timestamp.
